### PR TITLE
add support for server-side hyderation

### DIFF
--- a/src/beacons/fill/index.tsx
+++ b/src/beacons/fill/index.tsx
@@ -5,9 +5,6 @@ import styles from './index.module.scss';
 import defaultStyles from '../index.module.scss';
 import {injectUniqueKeyframe} from '../../utils/cssInjector';
 
-const styleEl = document.createElement('style');
-document.head.appendChild(styleEl);
-
 const FillBeacon = forwardRef<HTMLSpanElement, BeaconProps>(
 	({size = 18, color = 'rgb(255, 0, 68)', className = '', style = {}}, ref) => {
 		const [animation, setAnimation] = useState('none');

--- a/src/utils/cssInjector.ts
+++ b/src/utils/cssInjector.ts
@@ -1,10 +1,20 @@
-const styleEl = document.createElement('style');
-styleEl.setAttribute('data-testid', 'injectUniqueKeyframe');
-document.head.appendChild(styleEl);
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const styleSheet = styleEl.sheet!;
+import {isOnServer} from './hydration';
+
+let styleSheet: CSSStyleSheet | undefined = undefined;
+
+if (!isOnServer) {
+	const styleEl = document.createElement('style');
+	styleEl.setAttribute('data-testid', 'injectUniqueKeyframe');
+	document.head.appendChild(styleEl);
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	styleSheet = styleEl.sheet!;
+}
 
 export const injectUniqueKeyframe = (keyframe: string, name: string) => {
+	if (styleSheet === undefined) {
+		return {animationName: '', rulesLength: 0};
+	}
+
 	// eslint-disable-next-line no-useless-escape
 	const escapedName = name.replace(/[\(|\)|\,|\ |\#|\%]/g, '');
 	const animationName = `animation-${escapedName}`;

--- a/src/utils/hydration.ts
+++ b/src/utils/hydration.ts
@@ -1,0 +1,5 @@
+/**
+ * Checks if the code is running on the server or the client.
+ * True if the code is running on the server, false if it is running on the client.
+ */
+export const isOnServer = typeof window === 'undefined';

--- a/src/utils/index.node.test.tsx
+++ b/src/utils/index.node.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @vitest-environment node
+ */
+
+import {injectUniqueKeyframe} from './cssInjector';
+import {isOnServer} from './hydration';
+
+describe('injectUniqueKeyframe', () => {
+	it('should set keyframes', () => {
+		const firstRule = 'first-test';
+		const keyframe = `0% {
+			transform: scale(0.5);
+			box-shadow: 0 0 0 0 red;
+		}
+		100% {
+			transform: scale(0.95);
+			box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+		}`;
+
+		const {rulesLength: firstAnimationNameRulesLength} = injectUniqueKeyframe(keyframe, firstRule);
+		expect(firstAnimationNameRulesLength).toBe(0);
+	});
+});
+
+describe('hydration', () => {
+	it('window should be undefined in ssr', () => {
+		expect(isOnServer).toBe(true);
+	});
+});

--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -4,6 +4,7 @@ import {generateHash} from './hashGenerator';
 import {manageHit, STORAGE} from './hitManager';
 import {renderHook} from '../test/utils';
 import {useSkipMountEffect} from './useSkipMountEffect';
+import {isOnServer} from './hydration';
 
 const mocks = {
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -82,5 +83,11 @@ describe('useSkipMountEffect', () => {
 		rerender({test: 2});
 		expect(spy).toBeCalled();
 		expect(result.current).toBe(false);
+	});
+});
+
+describe('hydration', () => {
+	it('window should not be undefined in csr', () => {
+		expect(isOnServer).toBe(false);
 	});
 });


### PR DESCRIPTION
## Why?
There are some cases when the application is getting hydrated on the server side. The `cssInjector` utility throws an error because the document is unavailable on the server side.

## What?
Support for server-side hydration is added. Made `style sheet` creation conditional and limited to client-side on the browser.
Also, the redundant `style sheet` creation of other files is removed.